### PR TITLE
added edit-event views and template. did not mess with styling yet.

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,7 @@ from .models import Musician, MusicianComment, Event, EventComment
 from .forms import MusicianForm, EventForm
 from users.models import User
 from django.views import View
+from django.contrib.auth.decorators import login_required 
 import json
 import datetime
 import os
@@ -75,3 +76,20 @@ class ShowMusician(View):
     def get(self, request, musician_pk):
         musician = get_object_or_404(Musician, pk=musician_pk)
         return render(request, 'core/show_musician.html', {"musician": musician})
+
+
+def edit_event(request, event_pk):
+    event = get_object_or_404(Event, pk=event_pk)
+    if request.method == "POST":
+        form = EventForm(instance=event, data=request.POST, files=request.FILES)
+        if form.is_valid():
+            event = form.save()
+            return redirect(to="event", pk=event_pk)
+    else:
+        form = EventForm(instance=event)
+
+    return render(
+        request,
+        "core/edit_event.html",
+        {"form": form, "event": event}
+    )

--- a/project/urls.py
+++ b/project/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('', core_views.Homepage.as_view(), name="homepage"),
     path('event/<int:pk>', core_views.EventPage.as_view(), name="event"),
+    path('event/<int:event_pk>/edit', core_views.edit_event, name="edit-event"),
     path('musician/<int:musician_pk>/event/add', core_views.AddEvent.as_view(), name="add-event"),
     path('musician/add/<int:user_pk>', core_views.AddMusicianInfo.as_view(), name="add-musician"),
     path('musician/<int:musician_pk>', core_views.ShowMusician.as_view(), name="show-musician"),

--- a/templates/core/edit_event.html
+++ b/templates/core/edit_event.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="event-add center">
+    <div>
+        <h1>Edit Event:</h1>
+        <form action="{% url 'edit-event' event_pk=event.pk %}" method="POST" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <div>
+                <button type="submit">Save</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+
+<script>
+    $(function () {
+        $("#id_date_time").datetimepicker({  format: 'm/d/Y H:i', 
+                                            stepping: 15,
+                                        }
+        );
+    });
+  </script>
+{% endblock content %}

--- a/templates/core/show_musician.html
+++ b/templates/core/show_musician.html
@@ -62,6 +62,9 @@
                         <p>
                             {{event.date_time}}
                         </p>
+                        {% if user == musician.user %}
+                        <a href="{% url 'edit-event' event_pk=event.pk %}">Edit this event</a>
+                        {% endif %}
                     </div>
             </div>
         </a>


### PR DESCRIPTION
this also verifies that the only person who can edit an event is the musician who created it. the only place for a musician to edit an event is on their profile as of now, but it wouldnt be hard to add that feature to the homepage as well. i didn't add styling, but was thinking about adding an icon instead of the words 'edit this event', but we can cross that bridge at another time.